### PR TITLE
Ensure logger output directory is created before saving

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -425,6 +425,10 @@ class logger(object):
 
 
     def save(self):
+        # Ensure the directory for the CSV exists
+        dir_path = os.path.dirname(self.data_path)
+        if dir_path:
+            os.makedirs(dir_path, exist_ok=True)
         # return self.log.to_csv(self.data_path, index=False, index_label=False)
         return self.log.to_csv(self.data_path, index=False)
 


### PR DESCRIPTION
## Summary
- Create parent directories for logger CSV files before writing

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68b9b015358083218ce3889fd2f2705b